### PR TITLE
E380 with Stand Alone VX3 works - Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@
 * Data is typically updated by E3 device on change of value.
 * Data of slave device (e.g. VX3) typically is available on external CAN, data of master device (e.g. Vitocal) typically is available on internal CAN
 * Will probably not work on stand alone devices. See open3e for this case.
-* Will probably work for energy meter E380 on stand alone VX3 configuration.
+* Works for energy meter E380 on stand alone VX3 configuration.
 * For E380 dids are set equal to CAN ids. CAN ids are restricted to 0x250,0x252,0x254,0x256,0x258,0x25A
 * To scan more than one device at the same time, start one instance for each device


### PR DESCRIPTION
Funktioniert super auch in der Konstellation E380 an einer VX3 (Stand Alone). 
Die Werte vom E380 werden ständig auf CAN ausgegeben.